### PR TITLE
Create Aragon Under Tooling Tab

### DIFF
--- a/docs/DAO-tooling/frameworks/Aragon.md
+++ b/docs/DAO-tooling/frameworks/Aragon.md
@@ -1,0 +1,65 @@
+# Aragon 
+
+## Overview
+
+Aragon is a project that offers templates, guides and other services to create and manage DAOs on the Ethereum blockchain.
+With the largest number of DAOs created using the Aragon framework, it currently leads the undestry in facilitating the creation and management of DAOs.
+
+## How to Aragon:
+
+Its services range from easily creating DAOs, aiding with the UI and OS used by the DAO, as well as offering a judicial framework within which DAOs can resolve disputes without central authorities.
+This network of services is currently transitioning from Aragon V1 to Aragon V2 yet, the principal services as of now are introduced below:
+- Read more about V2 Changes [here](https://blog.aragon.one/court-to-protocol/)
+
+#### Creating A DAO
+
+Using [Aragon Client](https://aragon.org/client) you can create your own DAO in five steps for less than $10 USD in Eth.
+
+First, you are presented with six governance templates which you can choose from depending on the type of organization you wish to create.
+After naming your organization, you may edit the initial template so it best fits your organization's needs.
+Although each template has its own suite of smart-contracts, the editing process allows you to further tailor the parameters that administer and structure your DAO.
+
+Aragon Client is trasitioning to [Aragon Govern](https://aragon.org/govern) within V2
+
+To learn more about building your DAO with aragorn read [this](https://medium.com/quiknode/building-daos-with-aragon-c8b95956a405) article.
+
+#### Dispute Resolution
+
+The [Aragon Court](https://aragon.org/old/court) facilitates consensus and dispute resolution in a decentralized manner.
+To do so it incentivizes jurors to participate by voting on rulings. The system abides according to a logic of majority rule such that, jurors who vote in favor of the final ruling are rewarded with the fees taken from juror's who voted for the minority ruling.
+
+To use this service Aragon's native ANT tokens must be converted to the ANJ token, however, with V2 the ANJ token is being [integrated](https://upgrade.aragon.org/#/) into the ANT token.\
+In parallel, Aragon Court is transitioning to [Aragon Protocol](https://aragon.org/protocol) whereby, other than transitioning from ANJ to ANT, othe jurors will be known as guardians who will be rewarded in ANT for their judicial participation in the network. 
+
+#### Voting, Coordination and Communication
+
+Aragon recently announced the launch [Aragon Voice](https://aragon.org/aragon-voice), a solution for creating and managing proposals in a "decentralized, cost effective and secure manner." \
+
+Its primary feature is free and secure voting supporting a wide variety of voting types.
+
+Read more about this new tool [here](https://blog.aragon.org/introducing-aragon-voice/).
+
+## References and Resources:
+
+Manifesto: https://aragon.org/manifesto
+
+Create:
+- V1 https://aragon.org/client
+- V2 https://aragon.org/govern
+- Guide https://medium.com/quiknode/building-daos-with-aragon-c8b95956a405
+
+Dispute Solutions:
+- V1 https://aragon.org/old/court
+- V2 https://aragon.org/protocol
+- Transition information https://upgrade.aragon.org/#/
+
+Voting Solutions:
+- Aragon Voice https://aragon.org/aragon-voice
+- Voice Launch Announcement https://blog.aragon.org/introducing-aragon-voice/
+
+V2 Information:
+- AntV2: https://upgrade.aragon.org/#/
+- Announcement: https://blog.aragon.one/court-to-protocol/
+
+Aragon Forum:
+https://forum.aragon.org/

--- a/docs/DAO-tooling/frameworks/Aragon.md
+++ b/docs/DAO-tooling/frameworks/Aragon.md
@@ -63,3 +63,6 @@ V2 Information:
 
 Aragon Forum:
 https://forum.aragon.org/
+
+Aragon Docs:
+https://hack.aragon.org/docs/getting-started.html


### PR DESCRIPTION
Changed Aragon Overview's location from DAO Ecosystem Tab to Tooling tab

Saw sub-section titled "How to DAO", realized aragon should follow under same tab